### PR TITLE
add riok/mapperly

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -599,6 +599,7 @@ repositories = [
   'github.com/responsively-org/responsively-app',
   'github.com/RetroShare/RetroShare',
   'github.com/rigetti/pyquil',
+  'github.com/riok/mapperly',
   'github.com/ripple/rippled',
   'github.com/rjsf-team/react-jsonschema-form',
   'github.com/rodrigo-arenas/Sklearn-genetic-opt',


### PR DESCRIPTION
#### ℹ️ Repository information

Adds [riok/mapperly](https://github.com/riok/mapperly) with [good-first-issues](https://github.com/riok/mapperly/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
