### PR TITLE
Added Graphweaver to the list of repositories

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -213,6 +213,7 @@ repositories = [
   'github.com/ethyca/fides',
   'github.com/ethyca/fidesops',
   'github.com/evhub/coconut',
+  'github.com/exogee-technology/graphweaver',
   'github.com/external-secrets/external-secrets',
   'github.com/facebook/docusaurus',
   'github.com/facebook/draft-js',


### PR DESCRIPTION
Hi! I wanted to add Graphweaver to the list of repositories. I think it would be a great fit. Thank you!

Here is a list to the issues page: https://github.com/exogee-technology/graphweaver/issues

#### ℹ️ Repository information

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
