### PR TITLE
Add '/contribute' to repo URLs

### DIFF
--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -9,7 +9,7 @@
       <div class="flex flex-row">
         <a
           :title="`Open ${repo.owner}/${repo.name} on GitHub`"
-          :href="repo.url"
+          :href="`${repo.url}/contribute`"
           target="_blank"
           rel="noopener noreferrer"
           class="text-xl font-bold group-hover:text-juniper"


### PR DESCRIPTION
Add '/contribute' to repo URLs to auto-redirect to beginner-friendly issues