### PR TITLE
Remove water.css

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -354,7 +354,6 @@ repositories = [
   'github.com/knative/serving',
   'github.com/knex/knex',
   'github.com/kodadot/nft-gallery',
-  'github.com/kognise/water.css',
   'github.com/komeiji-satori/Dress',
   'github.com/Kong/insomnia',
   'github.com/Kong/kong',


### PR DESCRIPTION
#### ℹ️ Repository information

Hey! I was a contributor on water.css. It's not really being actively maintained right now, and it's leading to some spam on the repository (https://github.com/kognise/water.css/issues/348). I'm proposing that we remove ourselves from this so that we're not leading beginners astray.