### PR TITLE
Change content 's initial zoom

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -19,7 +19,7 @@ export default {
     ],
     meta: [
       { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { name: 'viewport', content: 'width=device-width, minimum-scale=1.0, maximum-scale=1.0' },
       {
         hid: 'description',
         name: 'description',


### PR DESCRIPTION
Changing the site's initial zoom setting.

#### The Problem
So when I view the site on mobile, the site is slightly zoomed in more than it's content width, and a user would have to zoom out a bit to get to the correct width. This issue is most likely caused due to some overflow in styling elements. 

#### The Solution
To fix this I have changed the content width to `maximum-scale=1.0, minimum-scale=1.0`. 
It prevents the site from being extra zoomed in when it initially loads, ensuring a smooth user experience. 

Please let me know if you have any questions!