### PR TITLE
Add LITIENGINE repository link.

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -287,6 +287,7 @@ repositories = [
   'github.com/grpc-ecosystem/grpc-gateway',
   'github.com/gruntwork-io/terragrunt',
   'github.com/Guake/guake',
+  'github.com/gurkenlabs/litiengine',
   'github.com/hackmdio/codimd',
   'github.com/hamaluik/timecop',
   'github.com/haproxy/haproxy',


### PR DESCRIPTION
#### ℹ️ Repository information
LITIENGINE is a free and open source Java 2D Game Engine. It provides a comprehensive Java library and a dedicated map editor to create tile-based 2D games.
https://github.com/gurkenlabs/litiengine/issues

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
