### PR TITLE
Remove awesome-piracy

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -307,7 +307,6 @@ repositories = [
   'github.com/Hypfer/Valetudo',
   'github.com/ibis-project/ibis',
   'github.com/Icinga/icinga2',
-  'github.com/Igglybuff/awesome-piracy',
   'github.com/imsnif/bandwhich',
   'github.com/indeedeng/starfish',
   'github.com/infection/infection',


### PR DESCRIPTION
awesome-piracy has been and archived and should therefore be removed.