### PR TITLE
Add "Back In Time"

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -81,6 +81,7 @@ repositories = [
   'github.com/billimarie/prosecutor-database',
   'github.com/biopython/biopython',
   'github.com/bisq-network/bisq',
+  'github.com/bit-team/backintime',
   'github.com/bitcoin/bitcoin',
   'github.com/bitwarden/clients',
   'github.com/bitwarden/mobile',


### PR DESCRIPTION
Hello,

adding [Back In Time](https://github.com/bit-team/backintime) project. The Issue section is at: https://github.com/bit-team/backintime/issues

Not sure how to answer the second bullet point. What time frame do we talk about? What is a "contributor"? Over the 15 years that project exists of course there are more then 10 of them. But currently the maintenance team consist of 3 members plus the formal maintainer in the back.

#### ℹ️ Repository information

**The repository has**:

- [X] At least three [issues with the `good first issue` label](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%3Aopen+label%3A%22GOOD+FIRST+ISSUE%22).
- [ ] At least 10 contributors.
- [X] Detailed setup instructions for the project.
- [X] [CONTRIBUTING.md](https://github.com/bit-team/backintime/blob/dev/CONTRIBUTING.md)
- [X] [Actively maintained](https://github.com/bit-team/backintime#maintenance-status).
