### PR TITLE
add glasskube/glasskube to repositories.toml

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -262,6 +262,7 @@ repositories = [
   'github.com/gitcommitshow/auth-jwt',
   'github.com/Giuliano1993/make-js-component',
   'github.com/gizak/termui',
+  'github.com/glasskube/glasskube',
   'github.com/Glavin001/atom-beautify',
   'github.com/globaleaks/GlobaLeaks',
   'github.com/glpi-project/glpi',


### PR DESCRIPTION
#### ℹ️ Repository information

**Glasskube**
🧊 The missing Package Manager for Kubernetes 📦 Featuring a GUI and a CLI. Glasskube packages are dependency aware, GitOps ready and can get automatic updates via a central public package repository.

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.

Issues: https://github.com/glasskube/glasskube/issues
