### PR TITLE
Add BlueWave Uptime to repositories.toml

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -86,6 +86,7 @@ repositories = [
   'github.com/bitwarden/mobile',
   'github.com/BlitzKraft/saythanks.io',
   'github.com/blockstack/blockstack-browser',
+  'github.com/bluewave-labs/bluewave-uptime',
   'github.com/bmarvinb/react-trello-clone',
   'github.com/boa-dev/boa',
   'github.com/bokeh/bokeh',


### PR DESCRIPTION
https://github.com/bluewave-labs/bluewave-uptime/issues

#### ℹ️ Repository information

**The repository has**:

- [ X ] At least three issues with the `good first issue` label.
- [ X ] At least 10 contributors.
- [ X ] Detailed setup instructions for the project.
- [ X ] CONTRIBUTING.md
- [ X ] Actively maintained.
