### PR TITLE
feat: drop sourcerer since its no longer maintained

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -686,7 +686,6 @@ repositories = [
   'github.com/solidusio/solidus',
   'github.com/sorbet/sorbet',
   'github.com/sourcegraph/sourcegraph',
-  'github.com/sourcerer-io/sourcerer-app',
   'github.com/spaceuptech/space-cloud',
   'github.com/spack/spack',
   'github.com/splitbrain/dokuwiki',


### PR DESCRIPTION
Sourcerer has shutdown as of march 31 of 2021.
While the repo itself is not archived, an Issue has been made with an official statement from the maintainers: https://github.com/sourcerer-io/sourcerer-app/issues/632
Also no chances have been made in the past 5 years.