### PR TITLE
Add Azure/PyRIT

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -67,6 +67,7 @@ repositories = [
   'github.com/awslabs/serverless-application-model',
   'github.com/axel-download-accelerator/axel',
   'github.com/Azure/mmlspark',
+  'github.com/Azure/PyRIT',
   'github.com/babel/babel',
   'github.com/badges/shields',
   'github.com/ballercat/walt',


### PR DESCRIPTION
#### ℹ️ Repository information

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [ ] CONTRIBUTING.md
- [x] Actively maintained.

Our issues are at https://github.com/Azure/PyRIT/issues. 29 of them are currently marked as "good first issues" vs. 46 with "help wanted" ("help wanted" without "good first issue" are the slightly more involved ones).

However, our GitHub README points to [our website](https://azure.github.io/PyRIT/contributing/README.html) which has an entire section on installation and contributing guides. Does that suffice or should we add a CONTRIBUTING.md that also points to the website?
