### PR TITLE
Show top three repository languages

### DIFF
--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -36,7 +36,7 @@
         class="flex-row flex text-sm py-1 font-mono"
         :class="{ 'text-honey': isCardOpen, 'text-vanilla-400': !isCardOpen }"
       >
-        <div class="mr-4"><span class="text-vanilla-400">lang: </span>{{ repo.language }}</div>
+        <div class="mr-4"><span class="text-vanilla-400">lang: </span>{{ languagesDisplay }}</div>
         <div class="mr-4"><span class="text-vanilla-400">stars: </span>{{ repo.stars_display }}</div>
         <div class="mr-4">
           <span class="text-vanilla-400">last activity: </span><span>{{ lastModifiedDisplay }}</span>
@@ -88,6 +88,10 @@ const openRepoId = useOpenRepoId()
 const issuesDisplay = computed(() => {
   const numIssues = props.repo.issues.length
   return numIssues > 1 ? `${numIssues} issues` : `${numIssues} issue`
+})
+
+const languagesDisplay = computed(() => {
+  return props.repo.languages?.join(', ') || props.repo.language
 })
 
 const lastModifiedDisplay = computed(() => {

--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -170,11 +170,16 @@ def get_repository_info(
             if good_first_issues and repository.language:
                 # store the repo info
                 info: RepositoryInfo = {}
+                languages = [language for language, _ in repository.languages(3)]
+                primary_language = languages[0] if languages else repository.language
+
                 info["name"] = name
                 info["owner"] = owner
                 info["description"] = emojize(repository.description or "")
-                info["language"] = repository.language
-                info["slug"] = slugify(repository.language, replacements=SLUGIFY_REPLACEMENTS)
+                info["language"] = primary_language
+                info["languages"] = languages
+                info["slug"] = slugify(primary_language, replacements=SLUGIFY_REPLACEMENTS)
+
                 info["url"] = repository.html_url
                 info["stars"] = repository.stargazers_count
                 info["stars_display"] = numerize.numerize(repository.stargazers_count)


### PR DESCRIPTION
## Summary

Shows up to three repository languages rather than only the primary language.

## Changes

- Fetches the top three repository languages from the GitHub languages endpoint.
- Stores them in the generated repository data as `languages`.
- Displays the language list in repository cards, with a fallback to the existing `language` field.

## Testing

- `uv run python gfi/test_data.py`
- `uv run mypy gfi/*.py`

## AI usage

I used ChatGPT/Codex to help understand the codebase, make the implementation, and verify the change.
