### PR TITLE
Add fallback UI for invalid language slugs and improve docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,13 @@ Good First Issue has two main components:
    cp data/tags.sample.json data/tags.json
    ```
 
+   On Windows PowerShell, you can also use:
+
+   ```powershell
+   Copy-Item data/generated.sample.json data/generated.json
+   Copy-Item data/tags.sample.json data/tags.json
+   ```
+
    These files contain:
    - `generated.json` - Repository metadata (stars, issues, languages, etc.)
    - `tags.json` - Language tags for filtering

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -1,6 +1,18 @@
 <template>
   <div class="p-4 w-full">
-    <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
+    <div v-if="!tag" class="text-center py-8">
+      <h1 class="text-2xl font-bold text-vanilla-100 mb-4">Language Not Found</h1>
+      <p class="text-vanilla-400 mb-6">Sorry, we don't have curated issues for "{{ slug }}" yet.</p>
+      <NuxtLink to="/" class="text-juniper hover:underline">← Back to all languages</NuxtLink>
+    </div>
+    <div v-else-if="repositories.length === 0" class="text-center py-8">
+      <h1 class="text-2xl font-bold text-vanilla-100 mb-4">No Projects Found</h1>
+      <p class="text-vanilla-400 mb-6">No {{ tag.language }} projects with good first issues are available right now.</p>
+      <NuxtLink to="/" class="text-juniper hover:underline">← Back to all languages</NuxtLink>
+    </div>
+    <div v-else>
+      <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
+    </div>
   </div>
 </template>
 
@@ -9,16 +21,18 @@ import Repositories from '~/data/generated.json'
 import Tags from '~/data/tags.json'
 
 const route = useRoute()
+const slug = route.params.slug
 
-const repositories = Repositories.filter(repository => repository.slug === route.params.slug)
+const repositories = Repositories.filter(repository => repository.slug === slug)
 
-const tag = Tags.find(t => t.slug === route.params.slug)
+const tag = Tags.find(t => t.slug === slug)
+const languageName = tag?.language ?? 'this language'
 
 useHead({
-  title: `${tag.language} | Good First Issue`,
+  title: `${languageName} | Good First Issue`,
   meta: [{
     name: 'description',
-    content: `Curated list of issues in ${tag.language} from popular open-source projects that you can easily fix.`
+    content: `Curated list of issues in ${languageName} from popular open-source projects that you can easily fix.`
   }]
 })
 </script>


### PR DESCRIPTION
## Changes Made

### 🛡️ Fixed Language Page Guard
- Added fallback UI for invalid language slugs (e.g., `/language/unknown`)
- Prevents crashes when accessing non-existent language pages
- Shows user-friendly error message with link back to homepage

### 📚 Improved Documentation  
- Added Windows PowerShell copy commands to CONTRIBUTING.md
- Makes setup easier for Windows users

### 🧪 Testing
- Visit `/language/javascript` (should work normally)
- Visit `/language/unknown` (should show error message instead of crashing)

## Type of Change
- [x] Bug fix (non-breaking change)
- [x] Documentation update
- [x] UI/UX improvement