### PR TITLE
Add Open Source Starter Lab

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -533,6 +533,7 @@ repositories = [
   'github.com/oven-sh/bun',
   'github.com/owncloud/client',
   'github.com/oxyplot/oxyplot',
+  'github.com/P-r-e-m-i-u-m/open-source-starter-lab',
   'github.com/p4lang/behavioral-model',
   'github.com/PalisadoesFoundation/talawa-admin',
   'github.com/panda3d/panda3d',


### PR DESCRIPTION
## Summary

Adds Open Source Starter Lab to the repository list.

Open Source Starter Lab is a beginner-friendly open-source lab with curated good first issues for Git, GitHub, pull requests, CI, TypeScript CLI work, and maintainer practice.

Repo: https://github.com/P-r-e-m-i-u-m/open-source-starter-lab

## Validation

I checked the TOML change manually. I could not run `uv run python gfi/test_data.py` locally because `uv` is not installed in this Windows environment.
