### PR TITLE
Add filters for minimum stars and recent activity within language results

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ Once your submission is reviewed and approved, it will be added to [goodfirstiss
 ## Contributing
 
 Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and guidelines.
+
+## Language page filters
+
+On `/language/:slug`, you can refine repositories with:
+
+- Minimum stars (`0`, `50`, `100`, `500`, `1000`, `5000`)
+- Recent activity (`Any`, `1 month`, `3 months`, `6 months`, `12 months`)
+
+Results are sorted by stars (descending), then by last activity (descending).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "sync": "bun sync.js"
+    "sync": "bun sync.js",
+    "test:unit": "node --test tests/repoFilters.test.js"
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -53,6 +53,13 @@ const activityMonths = ref(0)
 
 const tag = computed(() => Tags.find(t => t.slug === route.params.slug))
 
+if (!tag.value) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Language not found'
+  })
+}
+
 const totalRepositories = computed(() => {
   return Repositories.filter(repository => repository.slug === route.params.slug).length
 })
@@ -67,7 +74,7 @@ const filteredRepositories = computed(() => {
 })
 
 useHead(() => {
-  const language = tag.value?.language || 'Language'
+  const language = tag.value.language
 
   return {
     title: `${language} | Good First Issue`,

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -1,24 +1,80 @@
 <template>
   <div class="p-4 w-full">
-    <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
+    <div class="mb-4 flex flex-col md:flex-row md:items-end gap-3">
+      <label class="text-sm text-vanilla-400">
+        Minimum stars
+        <select v-model.number="minimumStars" class="ml-2 bg-ink-300 border border-ink-200 rounded px-2 py-1 text-vanilla-200">
+          <option v-for="starsOption in minimumStarsOptions" :key="starsOption" :value="starsOption">
+            {{ starsOption }}
+          </option>
+        </select>
+      </label>
+      <label class="text-sm text-vanilla-400">
+        Recent activity
+        <select v-model.number="activityMonths" class="ml-2 bg-ink-300 border border-ink-200 rounded px-2 py-1 text-vanilla-200">
+          <option v-for="activityOption in activityOptions" :key="activityOption.value" :value="activityOption.value">
+            {{ activityOption.label }}
+          </option>
+        </select>
+      </label>
+    </div>
+
+    <p class="text-sm text-vanilla-400 mb-4">
+      Showing {{ filteredRepositories.length }} of {{ totalRepositories }}
+    </p>
+
+    <p v-if="filteredRepositories.length === 0" class="text-sm border border-ink-200 rounded-md p-4">
+      No repositories match the selected filters.
+    </p>
+
+    <RepoBox v-for="repo in filteredRepositories" :key="repo.id" :repo="repo" />
   </div>
 </template>
 
 <script setup>
 import Repositories from '~/data/generated.json'
 import Tags from '~/data/tags.json'
+import { filterAndSortRepositories } from '~/utils/repoFilters'
 
 const route = useRoute()
 
-const repositories = Repositories.filter(repository => repository.slug === route.params.slug)
+const minimumStarsOptions = [0, 50, 100, 500, 1000, 5000]
 
-const tag = Tags.find(t => t.slug === route.params.slug)
+const activityOptions = [
+  { label: 'Any', value: 0 },
+  { label: '1 month', value: 1 },
+  { label: '3 months', value: 3 },
+  { label: '6 months', value: 6 },
+  { label: '12 months', value: 12 }
+]
 
-useHead({
-  title: `${tag.language} | Good First Issue`,
-  meta: [{
-    name: 'description',
-    content: `Curated list of issues in ${tag.language} from popular open-source projects that you can easily fix.`
-  }]
+const minimumStars = ref(0)
+const activityMonths = ref(0)
+
+const tag = computed(() => Tags.find(t => t.slug === route.params.slug))
+
+const totalRepositories = computed(() => {
+  return Repositories.filter(repository => repository.slug === route.params.slug).length
+})
+
+const filteredRepositories = computed(() => {
+  // Ordering rule: stars desc, then last_modified desc.
+  return filterAndSortRepositories(Repositories, {
+    slug: route.params.slug,
+    minStars: minimumStars.value,
+    activityMonths: activityMonths.value
+  })
+})
+
+useHead(() => {
+  const language = tag.value?.language || 'Language'
+
+  return {
+    title: `${language} | Good First Issue`,
+    meta: [{
+      name: 'description',
+      content: `Curated list of issues in ${language} from popular open-source projects that you can easily fix.`
+    }]
+  }
 })
 </script>

--- a/tests/repoFilters.test.js
+++ b/tests/repoFilters.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { filterAndSortRepositories } from '../utils/repoFilters.js'
+
+const repositories = [
+  { id: '1', slug: 'python', stars: 500, last_modified: '2026-05-01T00:00:00Z' },
+  { id: '2', slug: 'python', stars: 500, last_modified: '2026-05-10T00:00:00Z' },
+  { id: '3', slug: 'python', stars: 100, last_modified: '2026-04-20T00:00:00Z' },
+  { id: '4', slug: 'python', stars: 50, last_modified: '2025-12-01T00:00:00Z' },
+  { id: '5', slug: 'javascript', stars: 1000, last_modified: '2026-05-15T00:00:00Z' }
+]
+
+test('filters by language slug and sorts by stars then last_modified', () => {
+  const result = filterAndSortRepositories(repositories, { slug: 'python' })
+  assert.deepEqual(result.map(repo => repo.id), ['2', '1', '3', '4'])
+})
+
+test('applies minimum stars filter', () => {
+  const result = filterAndSortRepositories(repositories, { slug: 'python', minStars: 200 })
+  assert.deepEqual(result.map(repo => repo.id), ['2', '1'])
+})
+
+test('applies recent activity filter with fixed now date', () => {
+  const result = filterAndSortRepositories(repositories, {
+    slug: 'python',
+    activityMonths: 3,
+    now: new Date('2026-05-16T00:00:00Z')
+  })
+  assert.deepEqual(result.map(repo => repo.id), ['2', '1', '3'])
+})
+
+test('combines minimum stars and recent activity filters', () => {
+  const result = filterAndSortRepositories(repositories, {
+    slug: 'python',
+    minStars: 200,
+    activityMonths: 1,
+    now: new Date('2026-05-16T00:00:00Z')
+  })
+  assert.deepEqual(result.map(repo => repo.id), ['2', '1'])
+})

--- a/utils/repoFilters.js
+++ b/utils/repoFilters.js
@@ -1,0 +1,41 @@
+function getTimestamp(value) {
+  const timestamp = new Date(value).getTime()
+  return Number.isNaN(timestamp) ? 0 : timestamp
+}
+
+function getThresholdDate(now, months) {
+  const threshold = new Date(now)
+  threshold.setMonth(threshold.getMonth() - months)
+  return threshold
+}
+
+export function filterAndSortRepositories(repositories, options = {}) {
+  const {
+    slug,
+    minStars = 0,
+    activityMonths = 0,
+    now = new Date()
+  } = options
+
+  const thresholdDate = activityMonths > 0 ? getThresholdDate(now, activityMonths) : null
+
+  return repositories
+    .filter(repository => !slug || repository.slug === slug)
+    .filter(repository => repository.stars >= minStars)
+    .filter(repository => {
+      if (!thresholdDate) {
+        return true
+      }
+      const lastModifiedDate = new Date(repository.last_modified)
+      if (Number.isNaN(lastModifiedDate.getTime())) {
+        return false
+      }
+      return lastModifiedDate >= thresholdDate
+    })
+    .sort((a, b) => {
+      if (b.stars !== a.stars) {
+        return b.stars - a.stars
+      }
+      return getTimestamp(b.last_modified) - getTimestamp(a.last_modified)
+    })
+}


### PR DESCRIPTION
Summary
Adds filtering controls to help users discover repositories within a selected programming language based on:

Minimum stars
Recent activity (updated within the last X months)
Or both combined
Changes
Extended the existing language filter to work together with stars and last activity filters
Added a minimum stars control (dropdown/slider)
Added a recent activity control (last activity within X months)
Updated the repository list to re-filter and sort in real time when selections change
Why
This improves discoverability by letting beginners quickly find projects that are popular, actively maintained, or both—rather than inactive/obscure repos.

How to test
Select a language (e.g., Python)
Set a minimum stars value and confirm the list updates
Set “recent activity within X months” and confirm the list updates
Enable both filters and confirm results match both criteria
Clear filters and confirm the full language list returns