### PR TITLE
chore: add Nuxt compatibility date

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+  compatibilityDate: '2026-05-23',
   devtools: { enabled: true },
   modules: ['@nuxtjs/tailwindcss', 'nuxt-gtag', 'nuxt-simple-sitemap'],
   nitro: {


### PR DESCRIPTION
## Summary

This PR adds the `compatibilityDate` option to `nuxt.config.ts`.

While setting up the project locally and running `bun dev`, Nuxt/Nitro displayed a warning recommending adding a compatibility date. This change removes the fallback warning during local development.

## Changes

- Added `compatibilityDate: '2026-05-23'` to `nuxt.config.ts`.

## Testing

Tested locally with:

```bash
bun dev