### PR TITLE
refactor: improve type safety and remove unnecessary decorators

### DIFF
--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from operator import itemgetter
 from os import getenv, path
-from typing import TypedDict, Dict, Union, Sequence, Optional
+from typing import TypedDict, Optional
 
 import toml
 
@@ -125,7 +125,27 @@ class RepositoryIdentifier(TypedDict):
     name: str
 
 
-RepositoryInfo = Dict["str", Union[str, int, Sequence]]
+class IssueInfo(TypedDict):
+    title: str
+    url: str
+    number: int
+    comments_count: int
+    created_at: str
+
+
+RepositoryInfo = TypedDict("RepositoryInfo", {
+    "name": str,
+    "owner": str,
+    "description": str,
+    "language": str,
+    "slug": str,
+    "url": str,
+    "stars": int,
+    "stars_display": str,
+    "last_modified": str,
+    "id": str,
+    "issues": list[IssueInfo],
+})
 
 
 def get_repository_info(

--- a/gfi/test_data.py
+++ b/gfi/test_data.py
@@ -24,30 +24,25 @@ def _get_data_from_json(file_path):
 class TestDataSanity(unittest.TestCase):
     """Test for sanity of the data file."""
 
-    @staticmethod
-    def test_data_file_exists():
+    def test_data_file_exists(self):
         """Verify that the data file exists."""
         assert os.path.exists(DATA_FILE_PATH)
 
-    @staticmethod
-    def test_labels_file_exists():
+    def test_labels_file_exists(self):
         """Verify that the labels file exists."""
         assert os.path.exists(LABELS_FILE_PATH)
 
-    @staticmethod
-    def test_data_file_sane():
+    def test_data_file_sane(self):
         """Verify that the file is a valid TOML with required data."""
         data = _get_data_from_toml(DATA_FILE_PATH)
         assert "repositories" in data
 
-    @staticmethod
-    def test_labels_file_sane():
+    def test_labels_file_sane(self):
         """Verify that the labels file is a valid JSON"""
         data = _get_data_from_json(LABELS_FILE_PATH)
         assert "labels" in data
 
-    @staticmethod
-    def test_no_duplicates():
+    def test_no_duplicates(self):
         """Verify that all entries are unique."""
         data = _get_data_from_toml(DATA_FILE_PATH)
         repos = data.get("repositories", [])


### PR DESCRIPTION
- Replace loose RepositoryInfo type alias (Dict[str, Union[str, int, Sequence]]) with strict TypedDict that documents all fields and their exact types.
- Add IssueInfo TypedDict for issue data structure.
- Remove unused typing imports (Dict, Union, Sequence).
- Remove redundant @staticmethod decorators from unittest test methods.
- AI Disclosure: This PR was created with assistance from Claude Code.