### PR TITLE
docs: add Windows setup instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,28 @@ Before you begin, make sure you have the following installed:
   ```
   Or via Homebrew: `brew install uv`. See [docs.astral.sh/uv](https://docs.astral.sh/uv/) for details.
 
+## Windows User
+
+The install commands only works for Linux and macOS Windows is not included, use these alternatives:
+
+- **Install Bun (PowerShell):**
+``` powershell
+powershell -c "irm bun.sh/install.ps1 | iex"
+```
+- ** Install uv (PowerShell):**
+```powershell
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+After installing both, add them to your PATH in the same terminal session before moving foward
+
+```powershell
+$env:Path = "C:\Users\<YourUsername>\.bun\bin;$env:Path"
+$env:Path = "C:\Users\<YourUsername>\.local\bin;$env:Path"
+```
+
+**Note:** Replace `<YourUserName>` wiht your actual Windows username, There PATH changes apply to the current terminal session only. To makr them permanent, add them to your system enviroment variables.
+
 ## Project Structure
 
 Good First Issue has two main components:


### PR DESCRIPTION
## What changed
Added a Windows Users section under Prerequisites in CONTRIBUTING.md 
with PowerShell-specific install commands for Bun and uv, and PATH 
setup instructions.

## Why
The existing install commands only work on Linux/macOS. Windows users 
hit errors when following the guide as-is. I experienced this firsthand 
while setting up the project and want to save others the same friction.

## AI Usage
I verified all commands personally on my Windows machine during setup.