### PR TITLE
feat: add streamlit to repositories list

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -688,6 +688,7 @@ repositories = [
   'github.com/statsmodels/statsmodels',
   'github.com/Stellarium/stellarium',
   'github.com/storybookjs/storybook',
+  'github.com/streamlit/streamlit',
   'github.com/strapi/strapi',
   'github.com/streamich/react-use',
   'github.com/streamlit/streamlit',


### PR DESCRIPTION
## What does this PR do?
Adds streamlit/streamlit to the curated repositories list.

## Why streamlit?
- ✅ Active Python project with good first issue labels
- ✅ 1000+ contributors
- ✅ Actively maintained with frequent commits
- ✅ Has detailed README and CONTRIBUTING docs

