### PR TITLE
Increase issue fetch limit for accurate issue counts

### DIFF
--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -29,7 +29,7 @@ LABELS_DATA_FILE = "data/labels.json"
 ISSUE_STATE = "open"
 ISSUE_SORT = "created"
 ISSUE_SORT_DIRECTION = "desc"
-ISSUE_LIMIT = 10
+ISSUE_LIMIT = 100
 SLUGIFY_REPLACEMENTS = [["#", "sharp"], ["+", "plus"]]
 MAX_INACTIVITY_DAYS = 90  # Skip repos inactive for more than 3 months
 


### PR DESCRIPTION
Fixes #2561

Increased ISSUE_LIMIT from 10 to 100 in populate.py.

Previously only the first 10 issues were fetched for a repository, which could cause the displayed issue count to be significantly lower than the actual number of open issues on GitHub.

This change allows more issues to be collected, improving the accuracy of the displayed issue count.