### PR TITLE
Add KTS-o7/better_bing_image_downloader

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -369,6 +369,7 @@ repositories = [
   'github.com/kstonekuan/tambourine-voice',
   'github.com/krishdevdb/reseter.css',
   'github.com/kshashikumar/mysql-gui',
+  'github.com/KTS-o7/better_bing_image_downloader',
   'github.com/ktorio/ktor',
   'github.com/kubearmor/kubearmor',
   'github.com/kubernetes-sigs/krew',


### PR DESCRIPTION
Adding `better-bing-image-downloader` to the curated list of repositories with newcomer-friendly issues.

**Repository:** https://github.com/KTS-o7/better_bing_image_downloader
**License:** MIT
**Language:** Python (3.8+)

**What it is:** A stdlib-only Python library + `bbid` CLI for bulk-downloading images from Bing or DuckDuckGo via `urllib`. No browser, no Selenium, no API key. At v3.5.1 on PyPI.

**Currently open `good first issue` issues (3):**
- [#27](https://github.com/KTS-o7/better_bing_image_downloader/issues/27) — Add a regression test for top-level package imports (~30 min)
- [#33](https://github.com/KTS-o7/better_bing_image_downloader/issues/33) — Add a CLI smoke test for `bbid --version` (~15 min)
- [#34](https://github.com/KTS-o7/better_bing_image_downloader/issues/34) — Add `manifest_path` to `Result.__repr__` (~10 min)

**Also has 3 `help wanted` and 1 `enhancement`:**
- #28 — Add a CI workflow (pytest + ruff + mypy on Python 3.8 / 3.10 / 3.12)
- #29 — Document `Downloader` thread-safety contract
- #30 — Deprecate the v3.1.x `_manifest.json` legacy file
- #31 — `min_dimension` filter for v3.6.0

**Why it fits:** Stdlib-only Python with a clean, embeddable API, TDD discipline, conventional commits, 149 passing tests + 2 network-gated, MIT licensed, actively maintained (7 releases in 2026).

**This PR is a single-line addition** to `data/repositories.toml`, inserted alphabetically between `kshashikumar/mysql-gui` and `ktorio/ktor`.

No AI was used to write this PR description; it was hand-written by the maintainer.