### PR TITLE
 added pagination to repositories list to optimize DOM rendering

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,67 @@
 <template>
-  <div class="p-4 w-full">
-    <RepoBox v-for="repo in Repositories" :key="repo.id" :repo="repo" />
+  <div>
+    <RepoBox 
+      v-for="repo in paginatedRepos" 
+      :key="repo.id" 
+      :repo="repo" 
+    />
+
+    <div class="flex items-center justify-center gap-4 mt-8 mb-8">
+      <button 
+        @click="prevPage" 
+        :disabled="currentPage === 1"
+        class="px-4 py-2 bg-gray-800 text-white rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-700"
+      >
+        Previous
+      </button>
+
+      <span class="text-white font-medium">
+        Page {{ currentPage }} of {{ totalPages }}
+      </span>
+
+      <button 
+        @click="nextPage" 
+        :disabled="currentPage === totalPages"
+        class="px-4 py-2 bg-gray-800 text-white rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-700"
+      >
+        Next
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup>
 import Repositories from '~/data/generated.json'
+
+import { ref, computed } from 'vue'
+
+
+const currentPage = ref(1)
+const itemsPerPage = 20
+
+const totalPages = computed(() => {
+  return Math.ceil(Repositories.length / itemsPerPage)
+})
+
+const paginatedRepos = computed(() => {
+  const start = (currentPage.value - 1) * itemsPerPage
+  const end = start + itemsPerPage
+  return Repositories.slice(start, end)
+})
+
+const nextPage = () => {
+  if (currentPage.value < totalPages.value) {
+    currentPage.value++
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+}
+
+const prevPage = () => {
+  if (currentPage.value > 1) {
+    currentPage.value--
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+}
 
 useHead({
   title: 'Good First Issue: Make your first open-source contribution',


### PR DESCRIPTION
### Summary of Changes
- Implements a paginated view in `pages/index.vue` showing 20 repositories per page (`itemsPerPage = 20`).
- Adds responsive Previous/Next pagination buttons with disabled states and page counters.
- Adds smooth window scrolling (`window.scrollTo`) when navigating between pages.

### Motivation & Performance Impact
As `generated.json` grows in size, rendering all repository `<RepoBox>` components simultaneously causes excessive DOM nodes and UI lag on mobile devices. Slicing the repository array into pages optimizes initial rendering performance and improves browsing UX.

### Verification
- [x] Verified clean build and local rendering via `bun dev`.
- [x] Tested pagination state on first and last pages.