### PR TITLE
Optimize TestDataSanity and refactor staticmethods

### DIFF
--- a/gfi/test_data.py
+++ b/gfi/test_data.py
@@ -24,35 +24,40 @@ def _get_data_from_json(file_path):
 class TestDataSanity(unittest.TestCase):
     """Test for sanity of the data file."""
 
-    @staticmethod
-    def test_data_file_exists():
+    
+    def test_data_file_exists(self):
         """Verify that the data file exists."""
-        assert os.path.exists(DATA_FILE_PATH)
+        self.assertTrue(os.path.exists(DATA_FILE_PATH))
 
-    @staticmethod
-    def test_labels_file_exists():
+    
+    def test_labels_file_exists(self):
         """Verify that the labels file exists."""
-        assert os.path.exists(LABELS_FILE_PATH)
+        self.assertTrue(os.path.exists(LABELS_FILE_PATH))
 
-    @staticmethod
-    def test_data_file_sane():
+    
+    def test_data_file_sane(self):
         """Verify that the file is a valid TOML with required data."""
         data = _get_data_from_toml(DATA_FILE_PATH)
-        assert "repositories" in data
+        self.assertIn("repositories", data)
 
-    @staticmethod
-    def test_labels_file_sane():
+    
+    def test_labels_file_sane(self):
         """Verify that the labels file is a valid JSON"""
         data = _get_data_from_json(LABELS_FILE_PATH)
-        assert "labels" in data
+        self.assertIn("labels", data)
 
-    @staticmethod
-    def test_no_duplicates():
+    
+    def test_no_duplicates(self):
         """Verify that all entries are unique."""
         data = _get_data_from_toml(DATA_FILE_PATH)
         repos = data.get("repositories", [])
-        print([item for item, count in Counter(repos).items() if count > 1])
-        assert len(repos) == len(set(repos))
+        duplicates=[item for item, count in Counter(repos).items() if count > 1]
+        self.assertEqual(
+        len(repos), 
+        len(set(repos)), 
+        f"Duplicate repositories found in TOML file: {duplicates}"
+    )
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi team, 

I have refactored `@staticmethod` into standard test methods with proper `unittest` assertions (`self.assertTrue`, `self.assertIn`) to get more descriptive error messages if tests fail.

Closes #2273

*Note: Used AI assistance (Gemini) to understand code bottlenecks and optimize the unit tests structure.*