### PR TITLE
chore: update incubator-superset path to official repository

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -25,7 +25,7 @@ repositories = [
   'github.com/apache/apisix',
   'github.com/apache/dubbo',
   'github.com/apache/incubator-doris',
-  'github.com/apache/incubator-superset',
+  'github.com/apache/superset',
   'github.com/apache/openwhisk',
   'github.com/apache/shardingsphere',
   'github.com/apache/skywalking',


### PR DESCRIPTION
## Description

Fixed the outdated repository path for Apache Superset. The link was pointing to the old incubator URL (`github.com/apache/incubator-superset`) and has been updated to the current official repository path (`github.com/apache/superset`) inside `data/repositories.toml`.

## Checklist
- [x] Outdated path updated correctly
- [x] Sorted alphabetically in the repository configuration list