### PR TITLE
add PortSwigger Academy Labs repository to data

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -829,4 +829,5 @@ repositories = [
   'github.com/zsh-users/zsh-completions',
   'github.com/zsh-users/zsh-syntax-highlighting',
   'github.com/zulip/zulip',
+  'github.com/CaNSu5806/PortSwigger-Academy-Labs',
 ]


### PR DESCRIPTION
I have added the PortSwigger Academy Labs repository to the repositories.toml file to share it with open-source contributors looking for cybersecurity projects.
Note: No AI tools were used for this simple data entry change, and everything is formatted correctly.