### PR TITLE
fix: prevent repository link clicks from toggling cards

### DIFF
--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -17,6 +17,7 @@
           rel="noopener noreferrer"
           class="text-lg font-semibold group-hover:text-juniper"
           :class="{ 'text-juniper': isCardOpen }"
+          @click.stop
           >{{ repo.owner }} / {{ repo.name }}</a
         >
         <span class="flex-1"></span>
@@ -53,6 +54,7 @@
             target="_blank"
             rel="noopener noreferrer"
             class="leading-snug font-medium hover:text-juniper text-vanilla-300 block flex-auto"
+            @click.stop
             >{{ issue.title }}</a
           >
           <div


### PR DESCRIPTION
## Summary
- Prevent repository and issue links from bubbling to the repository card toggle handler.
- Keep the card state unchanged when a user opens an external GitHub link.

## Testing
- `uv run python gfi/test_data.py`
- `git diff --check`

## Not run
- Nuxt build and Prettier checks (Bun is not installed in the local environment).