### PR TITLE
docs: replace HTML entity with em dash character in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Open-source maintainers are always looking to get more people involved, but new 
 
 ## Adding a new project
 
-You're welcome to add a new project to Good First Issue, and we encourage all projects &mdash; old and new, big and small.
+You're welcome to add a new project to Good First Issue, and we encourage all projects --- old and new, big and small.
 
 **[Submit your repository via this form](https://docs.google.com/forms/d/e/1FAIpQLSfHSt8UHvACokWv8uwiImidTIhuSCAUXnvSGs-TULshdLl9Qw/viewform?usp=header)**
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Open-source maintainers are always looking to get more people involved, but new 
 
 ## Adding a new project
 
-You're welcome to add a new project to Good First Issue, and we encourage all projects --- old and new, big and small.
+You're welcome to add a new project to Good First Issue, and we encourage all projects - old and new, big and small.
 
 **[Submit your repository via this form](https://docs.google.com/forms/d/e/1FAIpQLSfHSt8UHvACokWv8uwiImidTIhuSCAUXnvSGs-TULshdLl9Qw/viewform?usp=header)**
 


### PR DESCRIPTION
## What
Replaced the `&mdash;` HTML entity with the actual em dash character (`—`) in README.md.

## Why
The HTML entity may not render correctly in plain markdown viewers. 
The actual character displays consistently everywhere.

## Type
- [x] Documentation fix
- [ ] Bug fix
- [ ] Feature