### PR TITLE
Add MSKazemi/yazses

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -462,6 +462,7 @@ repositories = [
   'github.com/MovingBlocks/Terasology',
   'github.com/MrSwitch/hello.js',
   'github.com/MSaifAsif/cqengine-next',
+  'github.com/MSKazemi/yazses',
   'github.com/mui-org/material-ui',
   'github.com/muke1908/chat-e2ee',
   'github.com/mumble-voip/mumble',


### PR DESCRIPTION
Adding **[YazSes](https://github.com/MSKazemi/yazses)** — voice dictation and speech-to-text for Linux, macOS and Windows. Hold a key, speak, release, and the text is typed into the focused window. Runs on the CPU with faster-whisper; nothing leaves the machine by default.

**Issues page:** https://github.com/MSKazemi/yazses/issues
**Good first issues:** https://github.com/MSKazemi/yazses/labels/good%20first%20issue

Against the acceptance criteria:

| Requirement | Status |
|---|---|
| ≥3 `good first issue` issues | **20 open** |
| ≥10 contributors | [contributors graph](https://github.com/MSKazemi/yazses/graphs/contributors) |
| `README.md` with setup instructions | [README](https://github.com/MSKazemi/yazses/blob/main/README.md) — install paths for PyPI, Snap, APT, macOS and Windows |
| `CONTRIBUTING.md` for new contributors | [CONTRIBUTING](https://github.com/MSKazemi/yazses/blob/main/CONTRIBUTING.md) — prerequisites, gates, and what to expect in review |
| Actively maintained | v2.17; the last six community PRs were reviewed and merged |

A good share of the open first issues need no Python at all — an example config, a known-good microphone, a README translation, or running it on your hardware and reporting back. The test suite is fully offline and runs in ~30s, so contributing needs no microphone, model download or GPU.

Entry inserted in sorted position (between `MSaifAsif/cqengine-next` and `mui-org/material-ui`); no other lines touched.