### PR TITLE
add risingwave to repository list

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -618,6 +618,7 @@ repositories = [
   'github.com/revertinc/revert',
   'github.com/rigetti/pyquil',
   'github.com/ripple/rippled',
+  'github.com/risingwavelabs/risingwave',
   'github.com/rjsf-team/react-jsonschema-form',
   'github.com/rodrigo-arenas/Sklearn-genetic-opt',
   'github.com/rolisteam/rolisteam',


### PR DESCRIPTION
## Summary

* Added `github.com/risingwavelabs/risingwave` to the repository list.
* Placed the repository in alphabetical order.

## Testing

* Ran `uv run python gfi/test_data.py`
* All 5 tests passed.

## AI Usage

I used ChatGPT to help me understand the repository's contribution workflow, inspect the relevant files, and verify the change. I reviewed the resulting change and ran the project's data sanity tests locally.
