### PR TITLE
Add Trendzza MiniBrowser repository

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -750,6 +750,7 @@ repositories = [
   'github.com/typetools/checker-framework',
   'github.com/typescript-eslint/typescript-eslint',
   'github.com/tzapu/WiFiManager',
+  'github.com/trendzza/minibrowser',
   'github.com/ubuntu/microk8s',
   'github.com/Udayraj123/OMRChecker',
   'github.com/unisonweb/unison',


### PR DESCRIPTION
## Add: Trendzza MiniBrowser

Adding [trendzza/minibrowser](https://github.com/trendzza/minibrowser) to the community repositories list.

**MiniBrowser** is a native Swift/WebKit browser for macOS built to be fast and memory-friendly (≈0.8–1.5 GB with 20 tabs vs. 6–10 GB on mainstream browsers). It is non-commercial open source and actively welcoming first-time contributors.

### Meets the requirements
- **Good First Issues:** 4 open issues with the `good first issue` label, e.g.
  - [Add more tracker domains to the ad-blocker rule set](https://github.com/trendzza/minibrowser/issues/1)
  - [Write MORE_README: FAQ + screenshots section](https://github.com/trendzza/minibrowser/issues/2)
  - [Improve error-page design when a site fails to load](https://github.com/trendzza/minibrowser/issues/3)
  - [Add a keyboard shortcut reference in the Command Palette](https://github.com/trendzza/minibrowser/issues/4)
- **README.md:** detailed setup + build instructions included
- **CONTRIBUTING.md:** contributor guide present
- **Active maintenance:** project recently and actively maintained
- **License:** valid open source (custom non-commercial, see LICENSE)
