### PR TITLE
Increase programming languages shown from top 1 to top 3

### DIFF
--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -36,7 +36,7 @@
         class="flex-row flex text-sm py-1 font-mono"
         :class="{ 'text-honey': isCardOpen, 'text-vanilla-400': !isCardOpen }"
       >
-        <div class="mr-4"><span class="text-vanilla-400">lang: </span>{{ repo.language }}</div>
+        <div class="mr-4"><span class="text-vanilla-400">langs: </span>{{ repo.languages ? repo.languages.join(', ') : repo.language }}</div>
         <div class="mr-4"><span class="text-vanilla-400">stars: </span>{{ repo.stars_display }}</div>
         <div class="mr-4">
           <span class="text-vanilla-400">last activity: </span><span>{{ lastModifiedDisplay }}</span>

--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -173,8 +173,42 @@ def get_repository_info(
                 info["name"] = name
                 info["owner"] = owner
                 info["description"] = emojize(repository.description or "")
+
+                # Fetch the top 3 languages.
+                rate_limiter.acquire()
+
+                try:
+                    languages = list(repository.languages())
+                    languages = sorted(
+                        languages,
+                        key=itemgetter(1),
+                        reverse=True,
+                    )
+                    top_languages = [
+                        language for language, _ in languages[:3]
+                    ]
+                except Exception as e:
+                    logger.warning(
+                        "Failed to fetch languages for {}/{}: {}",
+                        owner,
+                        name,
+                        e,
+                    )
+                    top_languages = []
+
+                # Fall back to the primary language if fetching languages fails.
+                if not top_languages:
+                    top_languages = [repository.language]
+
                 info["language"] = repository.language
+                info["languages"] = top_languages
                 info["slug"] = slugify(repository.language, replacements=SLUGIFY_REPLACEMENTS)
+                info["slugs"] = [
+                    slugify(
+                        language, replacements=SLUGIFY_REPLACEMENTS
+                        )
+                        for language in top_languages
+                        ]
                 info["url"] = repository.html_url
                 info["stars"] = repository.stargazers_count
                 info["stars_display"] = numerize.numerize(repository.stargazers_count)
@@ -264,7 +298,9 @@ if __name__ == "__main__":
         for result in results:
             if result:
                 REPOSITORIES.append(result)
-                TAGS[result["language"]] += 1
+
+                for language in result.get("languages", [result["language"]]):
+                    TAGS[language] += 1
 
     # write to generated JSON files
 

--- a/gfi/test_data.py
+++ b/gfi/test_data.py
@@ -4,8 +4,14 @@ import json
 import os
 import unittest
 from collections import Counter
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 import toml
+
+from gfi.populate import get_repository_info
+
+
 
 DATA_FILE_PATH = "data/repositories.toml"
 LABELS_FILE_PATH = "data/labels.json"
@@ -54,6 +60,90 @@ class TestDataSanity(unittest.TestCase):
         print([item for item, count in Counter(repos).items() if count > 1])
         assert len(repos) == len(set(repos))
 
+class TestPopulate(unittest.TestCase):
+    """Test repository data population."""
+
+    def test_get_repository_info_languages(self):
+        """Verify that the top 3 repository languages are stored."""
+        mock_repo = MagicMock()
+        mock_repo.language = "Python"
+        mock_repo.description = "A test repository"
+
+        # Intentionally not sorted to verify that the code sorts by usage.
+        mock_repo.languages.return_value = [
+            ("JavaScript", 300),
+            ("Python", 1000),
+            ("HTML", 100),
+            ("TypeScript", 500),
+        ]
+
+        info = get_repository_info(
+            mock_repo,
+            "test-owner",
+            "test-repo",
+        )
+
+        self.assertEqual(
+            info["languages"],
+            ["Python", "TypeScript", "JavaScript"],
+        )
+        self.assertEqual(
+            info["slugs"],
+            ["python", "typescript", "javascript"],
+        )
+
+
+
+class TestPopulate(unittest.TestCase):
+    """Test repository data population."""
+
+    def test_get_repository_info_languages(self):
+        """Verify that the top 3 repository languages are stored."""
+        identifier = {
+            "owner": "test-owner",
+            "name": "test-repo",
+        }
+
+        mock_client = MagicMock()
+        mock_rate_limiter = MagicMock()
+        mock_repo = MagicMock()
+
+        mock_repo.archived = False
+        mock_repo.pushed_at = datetime.now(timezone.utc)
+        mock_repo.language = "Python"
+        mock_repo.description = "A test repository"
+        mock_repo.html_url = "https://github.com/test-owner/test-repo"
+        mock_repo.stargazers_count = 100
+        mock_repo.id = 12345
+
+        # Return no issues so the repository passes the issue check.
+        mock_repo.issues.return_value = [MagicMock()]
+
+
+        # Intentionally unsorted to verify sorting by usage.
+        mock_repo.languages.return_value = [
+            ("JavaScript", 300),
+            ("Python", 1000),
+            ("HTML", 100),
+            ("TypeScript", 500),
+        ]
+
+        mock_client.repository.return_value = mock_repo
+
+        info = get_repository_info(
+            identifier,
+            mock_client,
+            mock_rate_limiter,
+        )
+
+        self.assertEqual(
+            info["languages"],
+            ["Python", "TypeScript", "JavaScript"],
+        )
+        self.assertEqual(
+            info["slugs"],
+            ["python", "typescript", "javascript"],
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -10,7 +10,13 @@ import Tags from '~/data/tags.json'
 
 const route = useRoute()
 
-const repositories = Repositories.filter(repository => repository.slug === route.params.slug)
+const repositories = Repositories.filter(repository => {
+  if (repository.slugs) {
+    return repository.slugs.includes(route.params.slug)
+  }
+
+  return repository.slug === route.params.slug
+})
 
 const tag = Tags.find(t => t.slug === route.params.slug)
 


### PR DESCRIPTION
## Description

This PR updates the repository language handling to show the top 3 programming languages used by each repository instead of only the primary language.

### Changes

- Fetch the top 3 programming languages from GitHub.
- Store the languages and their corresponding slugs in the generated repository data.
- Update language pages to include repositories where the language is one of the top 3.
- Update language tag counts to include all top 3 languages.
- Update the repository card to display multiple languages.
- Add a test covering language sorting and top 3 selection.

### Testing

- `uv run python gfi/test_data.py`
- `uv run python -m py_compile gfi/populate.py`
- `git diff --check`

All tests pass.

### AI Disclosure

AI assistance was used during development. The generated code was reviewed, tested, and verified locally.